### PR TITLE
Export helm repo name as a env variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ docker build -t $REPO:latest .
 docker tag $REPO:latest $REPO:$TAG_TO_USE
 docker build -t $REPO:latest-node -f DockerfileNode .
 docker tag $REPO:latest-node $REPO:$TAG_TO_USE-node
-docker build -t $REPO:latest-helm -f DockerfileHelm .
-docker tag $REPO:latest-helm $REPO:$TAG_TO_USE-helm
+docker build -t $REPO:latest-node -f DockerfileHelm .
+docker tag $REPO:latest-node $REPO:$TAG_TO_USE-helm

--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ docker build -t $REPO:latest .
 docker tag $REPO:latest $REPO:$TAG_TO_USE
 docker build -t $REPO:latest-node -f DockerfileNode .
 docker tag $REPO:latest-node $REPO:$TAG_TO_USE-node
-docker build -t $REPO:latest-node -f DockerfileHelm .
-docker tag $REPO:latest-node $REPO:$TAG_TO_USE-helm
+docker build -t $REPO:latest-helm -f DockerfileHelm .
+docker tag $REPO:latest-helm $REPO:$TAG_TO_USE-helm

--- a/configure-helm.sh
+++ b/configure-helm.sh
@@ -15,6 +15,7 @@ echo "setting up helm..."
 
 SSL_CA_BUNDLE_FILE=/etc/ssl/certs/ca-certificates.crt
 HELM_CERT_LOCATION=/usr/local/certificates
+export HELM_REPO=helmet
 export HELM_REPO_CRT_FILE=$HELM_CERT_LOCATION/client.crt
 export HELM_REPO_KEY_FILE=$HELM_CERT_LOCATION/client.key
 
@@ -23,6 +24,6 @@ echo $HELM_REPO_CRT | base64 -d > $HELM_REPO_CRT_FILE
 echo $HELM_REPO_KEY | base64 -d > $HELM_REPO_KEY_FILE
 
 helm init --client-only
-helm repo add helmet $HELM_REPO_URL/charts/ --ca-file $SSL_CA_BUNDLE_FILE --cert-file $HELM_REPO_CRT_FILE --key-file $HELM_REPO_KEY_FILE
+helm repo add $HELM_REPO $HELM_REPO_URL/charts/ --ca-file $SSL_CA_BUNDLE_FILE --cert-file $HELM_REPO_CRT_FILE --key-file $HELM_REPO_KEY_FILE
 
 echo ""


### PR DESCRIPTION
To make the release process more generic, we should export the helm repo name as an env variable.