### PR TITLE
Remove KUBE_CA_PEM_FILE input variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ docker build -t $REPO:latest .
 docker tag $REPO:latest $REPO:$TAG_TO_USE
 docker build -t $REPO:latest-node -f DockerfileNode .
 docker tag $REPO:latest-node $REPO:$TAG_TO_USE-node
-docker build -t $REPO:latest-helm -f DockerfileHelm .
-docker tag $REPO:latest-helm $REPO:$TAG_TO_USE-helm
+docker build -t $REPO:latest-node -f DockerfileHelm .
+docker tag $REPO:latest-node $REPO:$TAG_TO_USE-helm

--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ docker build -t $REPO:latest .
 docker tag $REPO:latest $REPO:$TAG_TO_USE
 docker build -t $REPO:latest-node -f DockerfileNode .
 docker tag $REPO:latest-node $REPO:$TAG_TO_USE-node
-docker build -t $REPO:latest-node -f DockerfileHelm .
-docker tag $REPO:latest-node $REPO:$TAG_TO_USE-helm
+docker build -t $REPO:latest-helm -f DockerfileHelm .
+docker tag $REPO:latest-helm $REPO:$TAG_TO_USE-helm

--- a/configure-helm.sh
+++ b/configure-helm.sh
@@ -4,7 +4,13 @@ set -eo pipefail
 
 echo "generating ~/.kube/config..."
 
-export KUBE_CLUSTER_OPTIONS=--certificate-authority="$KUBE_CA_PEM_FILE"
+CERTIFICATES_LOCATION=/usr/local/certificates
+KUBE_CA_PEM_FILE=$CERTIFICATES_LOCATION/kube.ca.pem
+
+mkdir -p $CERTIFICATES_LOCATION
+echo $KUBE_CA_PEM | base64 -d > $KUBE_CA_PEM_FILE
+
+KUBE_CLUSTER_OPTIONS=--certificate-authority="$KUBE_CA_PEM_FILE"
 
 kubectl config set-cluster kube-cluster --server="$KUBE_URL" $KUBE_CLUSTER_OPTIONS
 kubectl config set-credentials kube-user --token="$KUBE_TOKEN" $KUBE_CLUSTER_OPTIONS
@@ -14,12 +20,10 @@ kubectl config use-context kube-cluster
 echo "setting up helm..."
 
 SSL_CA_BUNDLE_FILE=/etc/ssl/certs/ca-certificates.crt
-HELM_CERT_LOCATION=/usr/local/certificates
 export HELM_REPO=helmet
-export HELM_REPO_CRT_FILE=$HELM_CERT_LOCATION/client.crt
-export HELM_REPO_KEY_FILE=$HELM_CERT_LOCATION/client.key
+export HELM_REPO_CRT_FILE=$CERTIFICATES_LOCATION/client.crt
+export HELM_REPO_KEY_FILE=$CERTIFICATES_LOCATION/client.key
 
-mkdir -p $HELM_CERT_LOCATION
 echo $HELM_REPO_CRT | base64 -d > $HELM_REPO_CRT_FILE
 echo $HELM_REPO_KEY | base64 -d > $HELM_REPO_KEY_FILE
 


### PR DESCRIPTION
Instead of receiving KUBE_CA_PEM_FILE, we will receive the certificate base64 encoded in the variable KUBE_CA_PEM. 